### PR TITLE
Datastorecsw

### DIFF
--- a/installation/install-ngds.sh
+++ b/installation/install-ngds.sh
@@ -735,12 +735,12 @@ function install_gdal() {
     run_or_die sudo apt-get update
     run_or_die sudo apt-get -y --force-yes install libgdal-dev gdal-bin
 
-    run_or_die $PYENV_DIR/bin/pip install --no-install GDAL
+    run_or_die $PYENV_DIR/bin/pip install --no-install GDAL==1.10.0
 
     pushd $PYENV_DIR/build/GDAL > /dev/null
     $PYENV_DIR/bin/python  setup.py build_ext --include-dirs=/usr/include/gdal/
 
-    run_or_die $PYENV_DIR/bin/pip install --no-download GDAL
+    run_or_die $PYENV_DIR/bin/pip install --no-download GDAL==1.10.0
     popd > /dev/null
 }
 


### PR DESCRIPTION
Installs the ckanext-datastorecsw plugin and fixes a GDAL installation error.

The addition of the ckanext-datastorecsw plugin unearthed a new error: the `resource_show` action seems to to be broken in our distribution.  We've never had any use for it before, which is why we probably never ran into the problem.  We can either fix the problem or upgrade to CKAN v2.2.0, which does have a working `resource_show` action.
